### PR TITLE
docker ignores more files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,11 @@
-app/.git/
-app/examples/
-app/spec/
-app/Dockerfile
-app/scripts/
-app/packaging/
+.circleci
+.git*
+app/
+!app/lib/
+!app/bin/
+!app/config/
+!app/data/
+!app/Gemfile
+!app/ssh_scan.gemspec
+!app/LICENSE
+ci/


### PR DESCRIPTION
The goal of this commit is to include _only_ the files
we really need to build the image.