### PR TITLE
ci: always describe HEAD for version

### DIFF
--- a/ci/build
+++ b/ci/build
@@ -5,7 +5,7 @@ git submodule sync
 git submodule update --init
 
 cat > ci/vars <<EOF
-export VERSION=$(cd app && git describe --tags --dirty)
+export VERSION=$(cd app && git describe --tags --always --dirty)
 export BUILD_DATE=$(date +%Y%m%dT%H%M)
 export VCS_REF=$(git rev-parse --short HEAD)
 export TAG=\${VERSION}_\${BUILD_DATE}_git_\${VCS_REF}


### PR DESCRIPTION
Generically, I plan to use this for more projects.
`--always` prints a reasonable output even if the directory lacks a tag.